### PR TITLE
ADD: eslint config with rulesets

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,59 @@
+{
+  "root": true,
+  "env": {
+      "browser": true,
+      "es2021": true,
+      "node": true
+  },
+  "extends": [
+    "plugin:vue/vue3-recommended",
+    "eslint:recommended",
+    "@vue/typescript/recommended"
+  ],
+  "parserOptions": {
+      "ecmaVersion": 2021
+  },
+  "rules": {
+    "@typescript-eslint/quotes": [
+      "error",
+      "single",
+      {
+        "avoidEscape": true,
+        "allowTemplateLiterals": true
+      }
+    ],
+    "vue/multi-word-component-names": "off",
+    "comma-dangle": ["error", {
+      "arrays": "only-multiline",
+      "objects": "only-multiline",
+      "imports": "only-multiline",
+      "exports": "only-multiline",
+      "functions": "only-multiline"
+    }],
+    "@typescript-eslint/member-delimiter-style": ["error", {
+      "multiline": {
+        "delimiter": "none",
+        "requireLast": true
+      },
+      "singleline": {
+        "delimiter": "semi",
+        "requireLast": false
+      }
+    }],
+    "vue/max-attributes-per-line": ["error", {
+      "singleline": {
+        "max": 3
+      },      
+      "multiline": {
+        "max": 1
+      }
+    }]
+  },
+  "overrides": [
+    {
+      "files": [
+        "**/*.spec.{j,t}s?(x)"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## New Configuration for ESLint

This is a base-config for eslint, that should work "out-of-the-box" in your editors if you have eslint plugin installed. It might require some additional configuration if you find any ruleset bonkers. If you see some error-message that you think is unnecessary read up on it on the link that the "problems" tab will give you, and decide on an action.

### Good to know
VSCode has an option to "autofix" the most simple linting errors, like converting " to ' and some option to lint first after these things are fixed. This way you wont get the annoying red-line when typing a function. 

Open User Settings (JSON) in VSCode and add `“eslint.run” : “onSave”` to the linting start first after a save action, and add the snippet below to fix the issues automatically.
```
“editor.codeActionsOnSave” : {
    “source.fixAll.eslint” : true
  },
```